### PR TITLE
Revert clone_stub, as it provides a really bad API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ trait Trait1 {
   fn self_method(&self, i32, i32, i32) -> i32;
   fn mut_self_method(&mut self, i32, i32, i32) -> i32;
   fn consuming_method(self, u32) -> u32;
-  fn method_with_ref(&mut self, &i32, i32) -> i32};
 }
 
 trait Trait2 {
@@ -34,7 +33,6 @@ create_stub! {
     self_method(i32, i32, i32) -> i32,
     mut_self_method(i32, i32, i32) -> i32,
     someone_elses_method(i32) -> i32
-    method_with_ref(i32, i32) -> i32}
   }
 }
 
@@ -44,7 +42,6 @@ instrument_stub! {
     {nostub static_method2(a: u32) -> u32}
     {stub self_method(&self, a: i32, b: i32, c: i32) -> i32}
     {stub mut_self_method(&mut self, a: i32, b: i32, c: i32) -> i32}
-    {clone_stub method_with_ref(&mut self, a: &i32, b: i32) -> i32}
     {nostub consuming_method(self, a: u32) -> u32}
   }
 }
@@ -55,10 +52,6 @@ instrument_stub! {
   }
 }
 ```
-Note: Return value must be cloneable so the stub can be called multiple times. If the method being stubbed takes references, you must stub them with clone_stub, and build the stub with the actual type rather than the reference as in the function signature. All of the arguments in a clone_stub method must be cloneable, to avoid lifetime issues.
-
-To recap: Return values must always be cloneable
-If a method takes any references it must be stubbed with clone_stub, and all args must be cloneable
 
 ### In your test
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ macro_rules! create_stub {
     impl $new_type {
       fn new() -> $new_type {
         $new_type {
-          $($fn_ident: StubHelper::new()),*,
+          $($fn_ident: StubHelper::new()),*
         }
       }
     }
@@ -83,36 +83,12 @@ macro_rules! impl_helper {
       }
     }
   };
-  (clone_stub $fn_ident:ident (&self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
-    fn $fn_ident (&self, $($arg_ident: $arg_type),*) -> $ret_type {
-      match self.$fn_ident.return_val.clone() {
-        Some(val) => {
-          let mut args = self.$fn_ident.call_args.borrow_mut();
-          args.push(($($arg_ident.clone()),*));
-          val
-        },
-        _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
-      }
-    }
-  };
   (stub $fn_ident:ident (&mut self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
     fn $fn_ident (&mut self, $($arg_ident: $arg_type),*) -> $ret_type {
       match self.$fn_ident.return_val.clone() {
         Some(val) => {
           let mut args = self.$fn_ident.call_args.borrow_mut();
           args.push(($($arg_ident),*));
-          val
-        },
-        _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
-      }
-    }
-  };
-  (clone_stub $fn_ident:ident (&mut self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
-    fn $fn_ident (&mut self, $($arg_ident: $arg_type),*) -> $ret_type {
-      match self.$fn_ident.return_val.clone() {
-        Some(val) => {
-          let mut args = self.$fn_ident.call_args.borrow_mut();
-          args.push(($($arg_ident.clone()),*));
           val
         },
         _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
@@ -168,7 +144,6 @@ mod tests {
   trait IssueCommenter {
     fn create_comment(&self, _: Repository, _: IssueId, details: CreateIssueComment) -> Result<IssueComment, GitErr>;
     fn create_fun(&self, _: u32) -> u32;
-    fn create_with_reference(&self, _: &u32) -> u32;
   }
 
   fn i_take_a_thing<T: IssueCommenter>(a: &T) {
@@ -178,8 +153,7 @@ mod tests {
   create_stub! {
     IssueCommenterStub {
       create_comment(Repository, IssueId, CreateIssueComment) -> Result<IssueComment, GitErr>,
-      create_fun(u32) -> u32,
-      create_with_reference(u32) -> u32
+      create_fun(u32) -> u32
     }
   }
 
@@ -187,7 +161,6 @@ mod tests {
     IssueCommenterStub as IssueCommenter {
       {stub create_comment (&self, a1: Repository, a2: IssueId, a3: CreateIssueComment) -> Result<IssueComment, GitErr>}
       {stub create_fun (&self, b1: u32) -> u32}
-      {clone_stub create_with_reference (&self, b1: &u32) -> u32}
     }
   }
 


### PR DESCRIPTION
Reverting this because the compiler errors from misusing it are really bad. I'll need to take a different approach to stubbing functions taking references.
