### PR TITLE
Enable stubbing functions that take borrows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ matrix:
     - rust: stable
       env: FEATURES=''
 script:
-   - cargo build --features "$FEATURES"
+   - cargo test --features "$FEATURES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: rust
 sudo: false
-rust:
-  - stable
-  - beta
-  - nightly
 matrix:
-  allow_failures:
+  include:
     - rust: nightly
+      env: FEATURES=nightly
+    - rust: beta
+      env: FEATURES=''
+    - rust: stable
+      env: FEATURES=''
+script:
+   - cargo build --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 name = "rusty-mock"
 version = "0.1.0"
 authors = ["Alex McArther <acmcarther@gmail.com>"]
+
+[features]
+nightly = []

--- a/README.md
+++ b/README.md
@@ -2,69 +2,10 @@
 
 [![Build Status](https://travis-ci.org/acmcarther/rusty-mock.svg?branch=master)](https://travis-ci.org/acmcarther/rusty-mock)
 
-Rusty-Mock provides a super quick macro for mocking out an implementor for your Trait. If you follow the practice of building traits for your application boundaries this lets you test them in isolation. The macro & interface is super raw, so please take care.
+Rusty-Mock provides some super quick macros for mocking out an implementor for your Trait. If you follow the practice of building traits for your application boundaries this lets you test them in isolation. The macro & interface is super raw, so please take care.
 
 ## Example
-### Creating some useful traits for us
-```Rust
-trait Trait1 {
-  fn static_method1(u32) -> u32;
-  fn static_method2(u32) -> u32;
-  fn self_method(&self, i32, i32, i32) -> i32;
-  fn mut_self_method(&mut self, i32, i32, i32) -> i32;
-  fn consuming_method(self, u32) -> u32;
-}
-
-trait Trait2 {
-  fn someone_elses_method(&self, i32) -> i32;
-}
-```
-### Creating a function using something implementing those traits
-```rust
-fn test_fn<Tester: Trait1 + Trait2>(x: &Tester) {
-  x.someone_elses_method(1);
-  x.self_method(1, 2, 3);
-}
-```
-### Stubbing out those traits (in your test)
-```rust
-create_stub! {
-  TraitStub2 {
-    self_method(i32, i32, i32) -> i32,
-    mut_self_method(i32, i32, i32) -> i32,
-    someone_elses_method(i32) -> i32
-  }
-}
-
-instrument_stub! {
-  TraitStub2 as Trait1 {
-    {nostub static_method1(a: u32) -> u32}
-    {nostub static_method2(a: u32) -> u32}
-    {stub self_method(&self, a: i32, b: i32, c: i32) -> i32}
-    {stub mut_self_method(&mut self, a: i32, b: i32, c: i32) -> i32}
-    {nostub consuming_method(self, a: u32) -> u32}
-  }
-}
-
-instrument_stub! {
-  TraitStub2 as Trait2 {
-    {stub someone_elses_method(&self, a: i32) -> i32}
-  }
-}
-```
-
-### In your test
-```rust
-#[test]
-fn it_was_called() {
-  let mut x = TraitStub1::new();
-  x.someone_elses_method.returns(5);
-  x.self_method.returns(5);
-  test_fn(&x);
-  assert!(x.self_method.was_called());
-  assert!(!x.mut_self_method.was_called());
-}
-```
+Example is gone for now, please check out the integration test for some examples.
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ impl<T: Clone, Interceptor: ?Sized> InterceptingStub<T, Interceptor> {
 
 #[macro_export]
 macro_rules! impl_helper {
-  (ArgWatchingStub $fn_ident:ident (&self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (ArgWatchingStub: $fn_ident:ident (&self $(, $arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     fn $fn_ident (&self, $($arg_ident: $arg_type),*) -> $ret_type {
       match self.$fn_ident.return_val.clone() {
         Some(val) => {
@@ -125,11 +125,11 @@ macro_rules! impl_helper {
           args.push(($($arg_ident),*));
           val
         },
-        _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
+        _ => panic!("#returns was not called on [{}] prior to invocation", stringify!($fn_ident))
       }
     }
   };
-  (InterceptingStub $fn_ident:ident (&self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (InterceptingStub: $fn_ident:ident (&self $(, $arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     fn $fn_ident (&self, $($arg_ident: $arg_type),*) -> $ret_type {
       match self.$fn_ident.return_val.clone() {
         Some(val) => {
@@ -140,11 +140,11 @@ macro_rules! impl_helper {
           self.$fn_ident.call_count.set(1 + self.$fn_ident.call_count.get());
           val
         },
-        _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
+        _ => panic!("#returns was not called on [{}] prior to invocation", stringify!($fn_ident))
       }
     }
   };
-  (SimpleStub $fn_ident:ident (&self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (SimpleStub: $fn_ident:ident (&self $(, $arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     #[allow(unused_variables)]
     fn $fn_ident (&self, $($arg_ident: $arg_type),*) -> $ret_type {
       match self.$fn_ident.return_val.clone() {
@@ -152,11 +152,11 @@ macro_rules! impl_helper {
           self.$fn_ident.call_count.set(1 + self.$fn_ident.call_count.get());
           val
         },
-        _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
+        _ => panic!("#returns was not called on [{}] prior to invocation", stringify!($fn_ident))
       }
     }
   };
-  (ArgWatchingStub $fn_ident:ident (&mut self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (ArgWatchingStub: $fn_ident:ident (&mut self $(, $arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     fn $fn_ident (&mut self, $($arg_ident: $arg_type),*) -> $ret_type {
       match self.$fn_ident.return_val.clone() {
         Some(val) => {
@@ -164,11 +164,11 @@ macro_rules! impl_helper {
           args.push(($($arg_ident),*));
           val
         },
-        _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
+        _ => panic!("#returns was not called on [{}] prior to invocation", stringify!($fn_ident))
       }
     }
   };
-  (InterceptingStub $fn_ident:ident (&mut self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (InterceptingStub: $fn_ident:ident (&mut self $(, $arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     fn $fn_ident (&mut self, $($arg_ident: $arg_type),*) -> $ret_type {
       match self.$fn_ident.return_val.clone() {
         Some(val) => {
@@ -176,11 +176,11 @@ macro_rules! impl_helper {
           self.$fn_ident.call_count.set(1 + self.$fn_ident.call_count.get());
           val
         },
-        _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
+        _ => panic!("#returns was not called on [{}] prior to invocation", stringify!($fn_ident))
       }
     }
   };
-  (SimpleStub $fn_ident:ident (&mut self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (SimpleStub: $fn_ident:ident (&mut self $(,$arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     #[allow(unused_variables)]
     fn $fn_ident (&mut self, $($arg_ident: $arg_type),*) -> $ret_type {
       match self.$fn_ident.return_val.clone() {
@@ -188,28 +188,28 @@ macro_rules! impl_helper {
           self.$fn_ident.call_count.set(1 + self.$fn_ident.call_count.get());
           val
         },
-        _ => panic!("#returns was not called on {} prior to invocation", stringify!($fn_ident))
+        _ => panic!("#returns was not called on [{}] prior to invocation", stringify!($fn_ident))
       }
     }
   };
-  (nostub $fn_ident:ident (&self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (nostub: $fn_ident:ident (&self $(, $arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     fn $fn_ident (&self, $(_: $arg_type),*) -> $ret_type {
-      panic!("Method was not stubbed {}", stringify!($fn_ident))
+      panic!("Method [{}] was not stubbed", stringify!($fn_ident))
     }
   };
-  (nostub $fn_ident:ident (&mut self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (nostub: $fn_ident:ident (&mut self $(,$arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     fn $fn_ident (&mut self, $(_: $arg_type),*) -> $ret_type {
-      panic!("Method was not stubbed {}", stringify!($fn_ident))
+      panic!("Method [{}] was not stubbed", stringify!($fn_ident))
     }
   };
-  (nostub $fn_ident:ident (self, $($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (nostub: $fn_ident:ident (self $(, $arg_ident:ident: $arg_type:ty)*) -> $ret_type:ty) => {
     fn $fn_ident (self, $(_: $arg_type),*) -> $ret_type {
-      panic!("Method {} not stubbed, and self-consuming methods cannot currently be stubbed", stringify!($fn_ident))
+      panic!("Method [{}] was not stubbed and self-consuming methods cannot currently be stubbed", stringify!($fn_ident))
     }
   };
-  (nostub $fn_ident:ident ($($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
+  (nostub: $fn_ident:ident ($($arg_ident:ident: $arg_type:ty),*) -> $ret_type:ty) => {
     fn $fn_ident ($(_: $arg_type),*) -> $ret_type {
-      panic!("Method {} not stubbed and static methods cannot currently be stubbed", stringify!($fn_ident))
+      panic!("Method [{}] was not stubbed and static methods cannot currently be stubbed", stringify!($fn_ident))
     }
   };
 }
@@ -218,11 +218,11 @@ macro_rules! impl_helper {
 macro_rules! instrument_stub {
   (
     $new_type:ty as $tr8:ident {
-      $({$stub_ty:ident: $($e:tt)*})*
+      $({$($e:tt)*})*
     }
   ) => {
     impl $tr8 for $new_type {
-      $(impl_helper!($stub_ty $($e)*);)*
+      $(impl_helper!($($e)*);)*
     }
   }
 
@@ -331,7 +331,7 @@ mod tests {
 
 
   #[test]
-  #[should_panic(expected = "#returns was not called on create_comment prior to invocation")]
+  #[should_panic(expected = "#returns was not called on [create_comment] prior to invocation")]
   fn panics_when_return_not_defined() {
     let stub = IssueCommenterStub::new();
     let _ = stub.create_comment(1, 2, 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#![feature(type_macros)]
+#![cfg_attr(feature = "nightly", feature(type_macros))]
+
 use std::cell::{Cell, RefCell};
 
 pub trait CallWatcher { fn call_count(&self) -> u32;
@@ -227,34 +228,39 @@ macro_rules! instrument_stub {
 
 }
 
-#[macro_export]
-macro_rules! build_stub_type {
-  (ArgWatchingStub ($($arg_type:ty),*) -> $ret_type:ty) => {
-    ArgWatchingStub<$ret_type, ($($arg_type),*)>
-  };
-  (SimpleStub ($($arg_type:ty),*) -> $ret_type:ty) => {
-    SimpleStub<$ret_type>
-  };
-  (InterceptingStub ($($arg_type:ty),*) -> $ret_type:ty) => {
-    InterceptingStub<$ret_type, Fn($($arg_type),*)>
-  };
-}
+#[cfg(feature = "nightly")]
+#[macro_use]
+mod type_macros {
 
-#[macro_export]
-macro_rules! create_stub {
-  (
-    $new_type:ident {
-      $({$stub_ty:ident: $fn_ident:ident $($e:tt)*})*
-    }
-  ) => {
-    struct $new_type {
-      $($fn_ident: build_stub_type!($stub_ty $($e)*)),*
-    }
+  #[macro_export]
+  macro_rules! build_stub_type {
+    (ArgWatchingStub ($($arg_type:ty),*) -> $ret_type:ty) => {
+      ArgWatchingStub<$ret_type, ($($arg_type),*)>
+    };
+    (SimpleStub ($($arg_type:ty),*) -> $ret_type:ty) => {
+      SimpleStub<$ret_type>
+    };
+    (InterceptingStub ($($arg_type:ty),*) -> $ret_type:ty) => {
+      InterceptingStub<$ret_type, Fn($($arg_type),*)>
+    };
+  }
 
-    impl $new_type {
-      fn new() -> $new_type {
-        $new_type {
-          $($fn_ident: $stub_ty::new()),*
+  #[macro_export]
+  macro_rules! create_stub {
+    (
+      $new_type:ident {
+        $({$stub_ty:ident: $fn_ident:ident $($e:tt)*})*
+      }
+    ) => {
+      struct $new_type {
+        $($fn_ident: build_stub_type!($stub_ty $($e)*)),*
+      }
+
+      impl $new_type {
+        fn new() -> $new_type {
+          $new_type {
+            $($fn_ident: $stub_ty::new()),*
+          }
         }
       }
     }
@@ -282,12 +288,33 @@ mod tests {
     let _ = a.create_comment(1, 2, 3);
   }
 
+  #[cfg(feature = "nightly")]
   create_stub! {
     IssueCommenterStub {
       {ArgWatchingStub: create_comment (Repository, IssueId, CreateIssueComment) -> Result<IssueComment, GitErr>}
       {ArgWatchingStub: create_fun (u32) -> u32}
       {SimpleStub: create_other (u32) -> u32}
       {InterceptingStub: create_more (&u32) -> u32}
+    }
+  }
+
+  #[cfg(not(feature = "nightly"))]
+  struct IssueCommenterStub {
+    create_comment: ArgWatchingStub<Result<IssueComment, GitErr>, (Repository, IssueId, CreateIssueComment)>,
+    create_fun: ArgWatchingStub<u32, (u32)>,
+    create_other: SimpleStub<u32>,
+    create_more: InterceptingStub<u32, Fn(&u32)>,
+  }
+
+  #[cfg(not(feature = "nightly"))]
+  impl IssueCommenterStub {
+    fn new() -> IssueCommenterStub {
+      IssueCommenterStub {
+        create_comment: ArgWatchingStub::new(),
+        create_fun: ArgWatchingStub::new(),
+        create_other: SimpleStub::new(),
+        create_more: InterceptingStub::new(),
+      }
     }
   }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -323,8 +323,8 @@ mod multiple_stub_types {
   }
 
   struct TraitStub {
-    arg_watching_stub: ArgWatchingStub<(i32), (i32, String)>,
-    intercepting_stub: InterceptingStub<(i32), Fn(&i32, &str)>,
+    arg_watching_stub: ArgWatchingStub<i32, (i32, String)>,
+    intercepting_stub: InterceptingStub<i32, Fn(&i32, &str)>,
   }
 
   impl TraitStub {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "nightly", feature(type_macros))]
+
 #[macro_use]
 extern crate rusty_mock;
 
@@ -139,99 +141,396 @@ mod simple_stub {
 }
 
 mod arg_watching_stub {
+  use rusty_mock::*;
+
+  trait Trait {
+    fn self_fn(&self);
+    fn mut_self_fn(&mut self);
+    fn self_fn_args_return(&self, i32) -> i32;
+  }
+
+  struct TraitStub {
+    self_fn: ArgWatchingStub<(), ()>,
+    mut_self_fn: ArgWatchingStub<(), ()>,
+    self_fn_args_return: ArgWatchingStub<i32, (i32)>
+  }
+
+  impl TraitStub {
+    fn new() -> TraitStub {
+      TraitStub {
+        self_fn: ArgWatchingStub::new(),
+        mut_self_fn: ArgWatchingStub::new(),
+        self_fn_args_return: ArgWatchingStub::new()
+      }
+    }
+  }
+
+  instrument_stub! {
+    TraitStub as Trait {
+      {ArgWatchingStub: self_fn (&self) -> ()}
+      {ArgWatchingStub: mut_self_fn (&mut self) -> ()}
+      {ArgWatchingStub: self_fn_args_return (&self, a: i32) -> i32}
+    }
+  }
+
+  #[test]
+  #[should_panic(expected = "#returns was not called on [self_fn] prior to invocation")]
+  fn panics_when_return_not_called_earlier() {
+    TraitStub::new().self_fn()
+  }
+
+  #[test]
+  fn responds_correctly_to_was_called_before_call() {
+    let stub = TraitStub::new();
+    assert!(!stub.self_fn.was_called());
+    assert!(!stub.mut_self_fn.was_called());
+    assert!(!stub.self_fn_args_return.was_called());
+  }
+
+  #[test]
+  fn records_calls_on_stubs() {
+    let mut stub = TraitStub::new();
+    stub.self_fn.returns(()); // TODO: Make this unnecessary, I know this is silly
+    stub.mut_self_fn.returns(());
+    stub.self_fn();
+    stub.mut_self_fn();
+    assert!(stub.self_fn.was_called());
+    assert!(stub.mut_self_fn.was_called());
+    assert!(stub.self_fn.was_called_once());
+    assert!(stub.mut_self_fn.was_called_once());
+    stub.self_fn();
+    stub.mut_self_fn();
+    assert!(stub.self_fn.was_called_n_times(2));
+    assert!(stub.mut_self_fn.was_called_n_times(2));
+  }
+
+  #[test]
+  fn returns_the_correct_value() {
+    let mut stub = TraitStub::new();
+    stub.self_fn_args_return.returns(10);
+    let result = stub.self_fn_args_return(1);
+    assert!(result == 10);
+  }
+
+  #[test]
+  fn remembers_the_call_args() {
+    let mut stub = TraitStub::new();
+    stub.self_fn_args_return.returns(10);
+    let _ = stub.self_fn_args_return(1);
+    assert!(stub.self_fn_args_return.was_called_with_args(&(1)));
+    assert!(!stub.self_fn_args_return.was_called_with_args(&(2)));
+    let _ = stub.self_fn_args_return(1);
+    assert!(stub.self_fn_args_return.always_called_with_args(&(1)));
+    let _ = stub.self_fn_args_return(2);
+    assert!(stub.self_fn_args_return.was_called_with_args(&(2)));
+  }
 }
 
 mod intercepting_stub {
+  use rusty_mock::*;
+
+  trait Trait {
+    fn self_fn(&self);
+    fn mut_self_fn(&mut self);
+    fn self_fn_args_return(&self, i32, &i32) -> i32;
+  }
+
+  struct TraitStub {
+    self_fn: InterceptingStub<(), Fn()>,
+    mut_self_fn: InterceptingStub<(), Fn()>,
+    self_fn_args_return: InterceptingStub<i32, Fn(i32, &i32)>
+  }
+
+  impl TraitStub {
+    fn new() -> TraitStub {
+      TraitStub {
+        self_fn: InterceptingStub::new(),
+        mut_self_fn: InterceptingStub::new(),
+        self_fn_args_return: InterceptingStub::new()
+      }
+    }
+  }
+
+  instrument_stub! {
+    TraitStub as Trait {
+      {InterceptingStub: self_fn (&self) -> ()}
+      {InterceptingStub: mut_self_fn (&mut self) -> ()}
+      {InterceptingStub: self_fn_args_return (&self, a: i32, b: &i32) -> i32}
+    }
+  }
+
+  #[test]
+  #[should_panic(expected = "#returns was not called on [self_fn] prior to invocation")]
+  fn panics_when_return_not_called_earlier() {
+    TraitStub::new().self_fn()
+  }
+
+  #[test]
+  fn responds_correctly_to_was_called_before_call() {
+    let stub = TraitStub::new();
+    assert!(!stub.self_fn.was_called());
+    assert!(!stub.mut_self_fn.was_called());
+    assert!(!stub.self_fn_args_return.was_called());
+  }
+
+  #[test]
+  fn records_calls_on_stubs() {
+    let mut stub = TraitStub::new();
+    stub.self_fn.returns(()); // TODO: Make this unnecessary, I know this is silly
+    stub.mut_self_fn.returns(());
+    stub.self_fn();
+    stub.mut_self_fn();
+    assert!(stub.self_fn.was_called());
+    assert!(stub.mut_self_fn.was_called());
+    assert!(stub.self_fn.was_called_once());
+    assert!(stub.mut_self_fn.was_called_once());
+    stub.self_fn();
+    stub.mut_self_fn();
+    assert!(stub.self_fn.was_called_n_times(2));
+    assert!(stub.mut_self_fn.was_called_n_times(2));
+  }
+
+  #[test]
+  fn returns_the_correct_value() {
+    let mut stub = TraitStub::new();
+    stub.self_fn_args_return.returns(10);
+    let result = stub.self_fn_args_return(1, &2);
+    assert!(result == 10);
+  }
+
+  #[test]
+  #[should_panic(expected = "Successfully executed interceptor test")]
+  fn calls_the_associated_fn_with_the_args() {
+    let mut stub = TraitStub::new();
+    stub.self_fn_args_return.returns(10);
+    stub.self_fn_args_return.set_interceptor(Box::new(move |x, y| {
+      assert!(x == *y && x == 1);
+      // Panicing is not suggested usage to indicate completion, but for this test it proves that
+      //   the test was executed
+      panic!("Successfully executed interceptor test");
+    }));
+    let _ = stub.self_fn_args_return(1, &1);
+  }
 }
 
 mod multiple_stub_types {
+  use rusty_mock::*;
+
+  trait Trait {
+    fn arg_watching_stub(&self, i32, String) -> i32;
+    fn intercepting_stub(&mut self, &i32, &str) -> i32;
+    fn no_stub(&self, i32, &i32, &str, &Box<Vec<Vec<Vec<&str>>>>) -> i32;
+  }
+
+  struct TraitStub {
+    arg_watching_stub: ArgWatchingStub<(i32), (i32, String)>,
+    intercepting_stub: InterceptingStub<(i32), Fn(&i32, &str)>,
+  }
+
+  impl TraitStub {
+    fn new() -> TraitStub {
+      TraitStub {
+        arg_watching_stub: ArgWatchingStub::new(),
+        intercepting_stub: InterceptingStub::new(),
+      }
+    }
+  }
+
+  instrument_stub! {
+    TraitStub as Trait {
+      {ArgWatchingStub: arg_watching_stub (&self, a: i32, b: String) -> i32}
+      {InterceptingStub: intercepting_stub (&mut self, a: &i32, b: &str) -> i32}
+      {nostub: no_stub (&self, a: i32, b: &i32, c: &str, d: &Box<Vec<Vec<Vec<&str>>>>) -> i32}
+    }
+  }
+
+  #[test]
+  #[should_panic(expected = "Method [no_stub] was not stubbed")]
+  fn non_stubbed_function_behaves_as_expected() {
+    let _ = TraitStub::new().no_stub(1, &2, "three", &Box::new(vec![vec![vec!["four"]]]));
+  }
+
+  #[test]
+  fn arg_watching_function_behaves_as_expected() {
+    let mut stub = TraitStub::new();
+    stub.arg_watching_stub.returns(10);
+    let _ = stub.arg_watching_stub(1, "Hello".to_owned());
+    assert!(stub.arg_watching_stub.was_called_with_args(&(1, "Hello".to_owned())));
+    assert!(!stub.arg_watching_stub.was_called_with_args(&(2, "Hello".to_owned())));
+    let _ = stub.arg_watching_stub(1, "Hello".to_owned());
+    assert!(stub.arg_watching_stub.always_called_with_args(&(1, "Hello".to_owned())));
+    let _ = stub.arg_watching_stub(2, "Hello".to_owned());
+    assert!(stub.arg_watching_stub.was_called_with_args(&(2, "Hello".to_owned())));
+  }
+
+  #[test]
+  fn interceptor_function_behaves_as_expeected() {
+    let mut stub = TraitStub::new();
+    stub.intercepting_stub.returns(10);
+    stub.intercepting_stub.set_interceptor(Box::new(move |x, y| {
+      assert!(*x == 1);
+      assert!(y == "hello");
+    }));
+    let _ = stub.intercepting_stub(&1, "hello");
+    assert!(stub.intercepting_stub.was_called_once());
+  }
 }
 
 mod multiple_trait_stub {
+  use rusty_mock::*;
+
+  trait FirstTrait {
+    fn give_a_string(&self, i32) -> String;
+  }
+
+  trait SecondTrait {
+    fn give_another_string(&self, i32) -> String;
+  }
+
+  struct TraitStub {
+    give_a_string: SimpleStub<String>,
+    give_another_string: SimpleStub<String>,
+  }
+
+  impl TraitStub {
+    fn new() -> TraitStub {
+      TraitStub {
+        give_a_string: SimpleStub::new(),
+        give_another_string: SimpleStub::new(),
+      }
+    }
+  }
+
+  instrument_stub! {
+    TraitStub as FirstTrait {
+      {SimpleStub: give_a_string (&self, a: i32) -> String}
+    }
+  }
+
+  instrument_stub! {
+    TraitStub as SecondTrait {
+      {SimpleStub: give_another_string (&self, a: i32) -> String}
+    }
+  }
+
+  fn takes_both_traits<T: FirstTrait + SecondTrait>(x: &T) -> String {
+    x.give_a_string(1) + &(x.give_another_string(2))
+  }
+
+  #[test]
+  fn multiple_traits_can_be_stubbed() {
+    let mut stub = TraitStub::new();
+    stub.give_a_string.returns("Hello ".to_owned());
+    stub.give_another_string.returns("World".to_owned());
+    let result = takes_both_traits(&stub);
+    assert!(stub.give_a_string.was_called_once());
+    assert!(stub.give_another_string.was_called_once());
+    assert!(&result == "Hello World");
+  }
+
 }
 
 #[cfg(feature = "nightly")]
 mod stub_create_macro {
-}
-/*
+  use rusty_mock::*;
+
+  type Repository = u32;
+  type IssueId = u32;
+  type CreateIssueComment = u32;
+  type IssueComment = u32;
+  type GitErr = u32;
+
+  trait Trait {
+    fn arg_watching_stub(&self, _: Repository, _: IssueId, details: CreateIssueComment) -> Result<IssueComment, GitErr>;
+    fn simple_stub(&self, _: u32) -> u32;
+    fn intercepting_stub(&self, _: &u32) -> u32;
+  }
+
+  create_stub! {
+    TraitStub {
+      {ArgWatchingStub: arg_watching_stub (Repository, IssueId, CreateIssueComment) -> Result<IssueComment, GitErr>}
+      {SimpleStub: simple_stub (u32) -> u32}
+      {InterceptingStub: intercepting_stub (&u32) -> u32}
+    }
+  }
+
+  instrument_stub! {
+    TraitStub as Trait {
+      {ArgWatchingStub: arg_watching_stub (&self, a1: Repository, a2: IssueId, a3: CreateIssueComment) -> Result<IssueComment, GitErr>}
+      {SimpleStub: simple_stub (&self, b1: u32) -> u32}
+      {InterceptingStub: intercepting_stub (&self, b1: &u32) -> u32}
+    }
+  }
+
   #[test]
-  #[should_panic(expected = "#returns was not called on create_comment prior to invocation")]
+  #[should_panic(expected = "#returns was not called on [arg_watching_stub] prior to invocation")]
   fn panics_when_return_not_defined() {
-    let stub = IssueCommenterStub::new();
-    let _ = stub.create_comment(1, 2, 3);
+    let stub = TraitStub::new();
+    let _ = stub.arg_watching_stub(1, 2, 3);
   }
 
   #[test]
   fn it_was_called() {
-    let mut stub = IssueCommenterStub::new();
-    stub.create_comment.returns(Err(5));
-    assert!(!stub.create_comment.was_called());
-    let _ = stub.create_comment(1, 2, 3);
-    assert!(stub.create_comment.was_called());
-    let _ = stub.create_comment(1, 2, 3);
-    assert!(stub.create_comment.was_called());
+    let mut stub = TraitStub::new();
+    stub.arg_watching_stub.returns(Err(5));
+    assert!(!stub.arg_watching_stub.was_called());
+    let _ = stub.arg_watching_stub(1, 2, 3);
+    assert!(stub.arg_watching_stub.was_called());
+    let _ = stub.arg_watching_stub(1, 2, 3);
+    assert!(stub.arg_watching_stub.was_called());
   }
 
   #[test]
   fn it_calls_the_args_correctly() {
-    let mut stub = IssueCommenterStub::new();
-    stub.create_comment.returns(Err(5));
-    let _ = stub.create_comment(1, 2, 3);
-    assert!(stub.create_comment.was_called_with_args(&(1,2,3)));
+    let mut stub = TraitStub::new();
+    stub.arg_watching_stub.returns(Err(5));
+    let _ = stub.arg_watching_stub(1, 2, 3);
+    assert!(stub.arg_watching_stub.was_called_with_args(&(1,2,3)));
   }
 
   #[test]
   fn it_calls_once() {
-    let mut stub = IssueCommenterStub::new();
-    stub.create_comment.returns(Err(5));
-    let _ = stub.create_comment(1, 2, 3);
-    assert!(stub.create_comment.was_called_once());
+    let mut stub = TraitStub::new();
+    stub.arg_watching_stub.returns(Err(5));
+    let _ = stub.arg_watching_stub(1, 2, 3);
+    assert!(stub.arg_watching_stub.was_called_once());
   }
 
   #[test]
   #[should_panic(expected = "assertion failed: *x == 5")]
   fn it_can_test_borrows_and_fail() {
-    let mut stub = IssueCommenterStub::new();
-    stub.create_more.set_interceptor(Box::new(move |x: &u32| assert!(*x == 5)));
-    stub.create_more.returns(10);
-    let _ = stub.create_more(&1);
+    let mut stub = TraitStub::new();
+    stub.intercepting_stub.set_interceptor(Box::new(move |x: &u32| assert!(*x == 5)));
+    stub.intercepting_stub.returns(10);
+    let _ = stub.intercepting_stub(&1);
   }
 
   #[test]
   fn it_can_test_borrows_and_succeed() {
-    let mut stub = IssueCommenterStub::new();
-    stub.create_more.set_interceptor(Box::new(move |x: &u32| assert!(*x == 1)));
-    stub.create_more.returns(10);
-    let _ = stub.create_more(&1);
-    assert!(stub.create_more.was_called_once());
+    let mut stub = TraitStub::new();
+    stub.intercepting_stub.set_interceptor(Box::new(move |x: &u32| assert!(*x == 1)));
+    stub.intercepting_stub.returns(10);
+    let _ = stub.intercepting_stub(&1);
+    assert!(stub.intercepting_stub.was_called_once());
   }
 
   #[test]
   fn it_never_calls_with_args() {
-    let mut stub = IssueCommenterStub::new();
-    stub.create_comment.returns(Err(5));
-    let _ = stub.create_comment(1, 2, 4);
-    assert!(stub.create_comment.never_called_with_args(&(1,2,3)));
-    let _ = stub.create_comment(1, 2, 3);
-    assert!(!stub.create_comment.never_called_with_args(&(1,2,3)));
+    let mut stub = TraitStub::new();
+    stub.arg_watching_stub.returns(Err(5));
+    let _ = stub.arg_watching_stub(1, 2, 4);
+    assert!(stub.arg_watching_stub.never_called_with_args(&(1,2,3)));
+    let _ = stub.arg_watching_stub(1, 2, 3);
+    assert!(!stub.arg_watching_stub.never_called_with_args(&(1,2,3)));
   }
 
   #[test]
   fn it_always_calls_with_args() {
-    let mut stub = IssueCommenterStub::new();
-    stub.create_comment.returns(Err(5));
-    let _ = stub.create_comment(1, 2, 3);
-    assert!(stub.create_comment.always_called_with_args(&(1,2,3)));
-    let _ = stub.create_comment(1, 2, 4);
-    assert!(!stub.create_comment.never_called_with_args(&(1,2,3)));
-  }
-
-  #[test]
-  fn it_works_in_place_of_the_trait() {
-    let mut stub = IssueCommenterStub::new();
-    stub.create_comment.returns(Err(5));
-    i_take_a_thing(&stub);
-    assert!(stub.create_comment.was_called());
+    let mut stub = TraitStub::new();
+    stub.arg_watching_stub.returns(Err(5));
+    let _ = stub.arg_watching_stub(1, 2, 3);
+    assert!(stub.arg_watching_stub.always_called_with_args(&(1,2,3)));
+    let _ = stub.arg_watching_stub(1, 2, 4);
+    assert!(!stub.arg_watching_stub.never_called_with_args(&(1,2,3)));
   }
 }
-*/

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,237 @@
+#[macro_use]
+extern crate rusty_mock;
+
+mod default_tests {
+  #[test]
+  fn it_works() {
+      assert_eq!(4, 4);
+  }
+}
+
+mod no_stub {
+  trait Trait {
+    fn no_self_fn();
+    fn self_fn(&self);
+    fn mut_self_fn(&mut self);
+    fn own_self_fn(self);
+    fn self_fn_args(&self, i32, &i32);
+  }
+
+  struct TraitStub;
+
+  impl TraitStub {
+    fn new() -> TraitStub { TraitStub }
+  }
+
+  instrument_stub! {
+    TraitStub as Trait {
+      {nostub: no_self_fn () -> ()}
+      {nostub: self_fn (&self) -> ()}
+      {nostub: mut_self_fn (&mut self) -> ()}
+      {nostub: own_self_fn (self) -> ()}
+      {nostub: self_fn_args (&self, a: i32, b: &i32) -> ()}
+    }
+  }
+
+  #[test]
+  #[should_panic(expected = "Method [no_self_fn] was not stubbed and static methods cannot currently be stubbed")]
+  fn panics_when_not_stubbed_no_self() {
+    let _ = TraitStub::no_self_fn();
+  }
+
+  #[test]
+  #[should_panic(expected = "Method [self_fn] was not stubbed")]
+  fn panics_when_not_stubbed_self_fn() {
+    TraitStub::new().self_fn()
+  }
+
+  #[test]
+  #[should_panic(expected = "Method [mut_self_fn] was not stubbed")]
+  fn panics_when_not_stubbed_mut_self_fn() {
+    TraitStub::new().mut_self_fn()
+  }
+
+  #[test]
+  #[should_panic(expected = "Method [own_self_fn] was not stubbed and self-consuming methods cannot currently be stubbed")]
+  fn panics_when_not_stubbed_consuming_self_fn() {
+    TraitStub::new().own_self_fn()
+  }
+
+  #[test]
+  #[should_panic(expected = "Method [self_fn_args] was not stubbed")]
+  fn panics_when_not_stubbed_self_fn_args() {
+    TraitStub::new().self_fn_args(5, &5)
+  }
+}
+
+mod simple_stub {
+  use rusty_mock::*;
+
+  trait Trait {
+    fn self_fn(&self);
+    fn mut_self_fn(&mut self);
+    fn self_fn_args_return(&self, i32, &i32) -> i32;
+  }
+
+  struct TraitStub {
+    self_fn: SimpleStub<()>,
+    mut_self_fn: SimpleStub<()>,
+    self_fn_args_return: SimpleStub<i32>
+  }
+
+  impl TraitStub {
+    fn new() -> TraitStub {
+      TraitStub {
+        self_fn: SimpleStub::new(),
+        mut_self_fn: SimpleStub::new(),
+        self_fn_args_return: SimpleStub::new()
+      }
+    }
+  }
+
+  instrument_stub! {
+    TraitStub as Trait {
+      {SimpleStub: self_fn (&self) -> ()}
+      {SimpleStub: mut_self_fn (&mut self) -> ()}
+      {SimpleStub: self_fn_args_return (&self, a: i32, b: &i32) -> i32}
+    }
+  }
+
+  #[test]
+  #[should_panic(expected = "#returns was not called on [self_fn] prior to invocation")]
+  fn panics_when_return_not_called_earlier() {
+    TraitStub::new().self_fn()
+  }
+
+  #[test]
+  fn responds_correctly_to_was_called_before_call() {
+    let stub = TraitStub::new();
+    assert!(!stub.self_fn.was_called());
+    assert!(!stub.mut_self_fn.was_called());
+    assert!(!stub.self_fn_args_return.was_called());
+  }
+
+  #[test]
+  fn records_calls_on_stubs() {
+    let mut stub = TraitStub::new();
+    stub.self_fn.returns(()); // TODO: Make this unnecessary, I know this is silly
+    stub.mut_self_fn.returns(());
+    stub.self_fn();
+    stub.mut_self_fn();
+    assert!(stub.self_fn.was_called());
+    assert!(stub.mut_self_fn.was_called());
+    assert!(stub.self_fn.was_called_once());
+    assert!(stub.mut_self_fn.was_called_once());
+    stub.self_fn();
+    stub.mut_self_fn();
+    assert!(stub.self_fn.was_called_n_times(2));
+    assert!(stub.mut_self_fn.was_called_n_times(2));
+  }
+
+  #[test]
+  fn returns_the_correct_value() {
+    let mut stub = TraitStub::new();
+    stub.self_fn_args_return.returns(10);
+    let result = stub.self_fn_args_return(1, &1);
+    assert!(result == 10);
+  }
+
+}
+
+mod arg_watching_stub {
+}
+
+mod intercepting_stub {
+}
+
+mod multiple_stub_types {
+}
+
+mod multiple_trait_stub {
+}
+
+#[cfg(feature = "nightly")]
+mod stub_create_macro {
+}
+/*
+  #[test]
+  #[should_panic(expected = "#returns was not called on create_comment prior to invocation")]
+  fn panics_when_return_not_defined() {
+    let stub = IssueCommenterStub::new();
+    let _ = stub.create_comment(1, 2, 3);
+  }
+
+  #[test]
+  fn it_was_called() {
+    let mut stub = IssueCommenterStub::new();
+    stub.create_comment.returns(Err(5));
+    assert!(!stub.create_comment.was_called());
+    let _ = stub.create_comment(1, 2, 3);
+    assert!(stub.create_comment.was_called());
+    let _ = stub.create_comment(1, 2, 3);
+    assert!(stub.create_comment.was_called());
+  }
+
+  #[test]
+  fn it_calls_the_args_correctly() {
+    let mut stub = IssueCommenterStub::new();
+    stub.create_comment.returns(Err(5));
+    let _ = stub.create_comment(1, 2, 3);
+    assert!(stub.create_comment.was_called_with_args(&(1,2,3)));
+  }
+
+  #[test]
+  fn it_calls_once() {
+    let mut stub = IssueCommenterStub::new();
+    stub.create_comment.returns(Err(5));
+    let _ = stub.create_comment(1, 2, 3);
+    assert!(stub.create_comment.was_called_once());
+  }
+
+  #[test]
+  #[should_panic(expected = "assertion failed: *x == 5")]
+  fn it_can_test_borrows_and_fail() {
+    let mut stub = IssueCommenterStub::new();
+    stub.create_more.set_interceptor(Box::new(move |x: &u32| assert!(*x == 5)));
+    stub.create_more.returns(10);
+    let _ = stub.create_more(&1);
+  }
+
+  #[test]
+  fn it_can_test_borrows_and_succeed() {
+    let mut stub = IssueCommenterStub::new();
+    stub.create_more.set_interceptor(Box::new(move |x: &u32| assert!(*x == 1)));
+    stub.create_more.returns(10);
+    let _ = stub.create_more(&1);
+    assert!(stub.create_more.was_called_once());
+  }
+
+  #[test]
+  fn it_never_calls_with_args() {
+    let mut stub = IssueCommenterStub::new();
+    stub.create_comment.returns(Err(5));
+    let _ = stub.create_comment(1, 2, 4);
+    assert!(stub.create_comment.never_called_with_args(&(1,2,3)));
+    let _ = stub.create_comment(1, 2, 3);
+    assert!(!stub.create_comment.never_called_with_args(&(1,2,3)));
+  }
+
+  #[test]
+  fn it_always_calls_with_args() {
+    let mut stub = IssueCommenterStub::new();
+    stub.create_comment.returns(Err(5));
+    let _ = stub.create_comment(1, 2, 3);
+    assert!(stub.create_comment.always_called_with_args(&(1,2,3)));
+    let _ = stub.create_comment(1, 2, 4);
+    assert!(!stub.create_comment.never_called_with_args(&(1,2,3)));
+  }
+
+  #[test]
+  fn it_works_in_place_of_the_trait() {
+    let mut stub = IssueCommenterStub::new();
+    stub.create_comment.returns(Err(5));
+    i_take_a_thing(&stub);
+    assert!(stub.create_comment.was_called());
+  }
+}
+*/

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -434,21 +434,15 @@ mod multiple_trait_stub {
 mod stub_create_macro {
   use rusty_mock::*;
 
-  type Repository = u32;
-  type IssueId = u32;
-  type CreateIssueComment = u32;
-  type IssueComment = u32;
-  type GitErr = u32;
-
   trait Trait {
-    fn arg_watching_stub(&self, _: Repository, _: IssueId, details: CreateIssueComment) -> Result<IssueComment, GitErr>;
-    fn simple_stub(&self, _: u32) -> u32;
-    fn intercepting_stub(&self, _: &u32) -> u32;
+    fn arg_watching_stub(&self, u32, u32, u32) -> Result<u32, u32>;
+    fn simple_stub(&self, u32) -> u32;
+    fn intercepting_stub(&self, &u32) -> u32;
   }
 
   create_stub! {
     TraitStub {
-      {ArgWatchingStub: arg_watching_stub (Repository, IssueId, CreateIssueComment) -> Result<IssueComment, GitErr>}
+      {ArgWatchingStub: arg_watching_stub (u32, u32, u32) -> Result<u32, u32>}
       {SimpleStub: simple_stub (u32) -> u32}
       {InterceptingStub: intercepting_stub (&u32) -> u32}
     }
@@ -456,7 +450,7 @@ mod stub_create_macro {
 
   instrument_stub! {
     TraitStub as Trait {
-      {ArgWatchingStub: arg_watching_stub (&self, a1: Repository, a2: IssueId, a3: CreateIssueComment) -> Result<IssueComment, GitErr>}
+      {ArgWatchingStub: arg_watching_stub (&self, a1: u32, a2: u32, a3: u32) -> Result<u32, u32>}
       {SimpleStub: simple_stub (&self, b1: u32) -> u32}
       {InterceptingStub: intercepting_stub (&self, b1: &u32) -> u32}
     }


### PR DESCRIPTION
Up until now, this was not possible. This PR adds a new stub type, InterceptingStub, that allows the user to set an "interceptor" that gets called with the arguments of the function. This allows the test code to be "injected" into the stub and executed at call time. 
